### PR TITLE
Changes in heavy industry update

### DIFF
--- a/Mod/Data/Scripts/HoverRail/HoverRailEngine.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverRailEngine.cs
@@ -61,7 +61,8 @@ namespace HoverRail
                 sinkComp.Init(
                     MyStringHash.GetOrCompute("Thrust"),
                     MAX_POWER_USAGE_MW,
-                    GetCurrentPowerDraw
+                    GetCurrentPowerDraw,
+                    (MyCubeBlock)Entity
                 );
                 Entity.Components.Add(sinkComp);
             }


### PR DESCRIPTION
MyResourceSinkComponent now requires the block passed as an argument